### PR TITLE
Add latency test

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Example file-based test:
 
 Results are saved to the report file (default `disks_test_report.txt`).
 
+## Included tests
+- Sequential read 1M Q1T1
+- Sequential write 1M Q1T1
+- Random read 4K Q1T1
+- Random write 4K Q1T1
+- Random read 4K Q32T16
+- Random write 4K Q32T16
+- Random read latency 4K Q1T1 (average access time)
+- Throttling test - continuous write 60s
+
 ## License
 The code is released under the GNU General Public License version 3.0.
 See the `LICENSE` file for details.

--- a/cdev_test
+++ b/cdev_test
@@ -128,6 +128,12 @@ run_test() {
     IOPS=$(jq 'if .jobs[0].write.iops == 0 then .jobs[0].read.iops else .jobs[0].write.iops end' "$TMP_JSON")
     UNIT="IOPS"
     RESULT="$IOPS $UNIT"
+  elif [[ "$NAME" == *"latency"* ]]; then
+    # Average access time (µs)
+    LAT=$(jq 'if .jobs[0].write.clat_ns.mean == 0 then .jobs[0].read.clat_ns.mean else .jobs[0].write.clat_ns.mean end' "$TMP_JSON")
+    LAT_US=$(awk "BEGIN { printf \"%.2f\", $LAT / 1000 }")
+    UNIT="us"
+    RESULT="$LAT_US $UNIT"
   else
     RESULT="Unknown test type"
   fi
@@ -148,6 +154,7 @@ run_test "randread-q1t1" "Random read 4K Q1T1" "--rw=randread --bs=4k --iodepth=
 run_test "randwrite-q1t1" "Random write 4K Q1T1" "--rw=randwrite --bs=4k --iodepth=1 --numjobs=1"
 run_test "randread-q32t16" "Random read 4K Q32T16" "--rw=randread --bs=4k --iodepth=32 --numjobs=16"
 run_test "randwrite-q32t16" "Random write 4K Q32T16" "--rw=randwrite --bs=4k --iodepth=32 --numjobs=16"
+run_test "latency-q1t1" "Random read latency 4K Q1T1" "--rw=randread --bs=4k --iodepth=1 --numjobs=1"
 run_test "long-write" "Throttling test - continuous write 60s" "--rw=write --bs=1M --iodepth=1 --numjobs=1 --runtime=60"
 
 # =========================


### PR DESCRIPTION
## Summary
- parse latency result when test name contains `latency`
- add new random read latency test in the script
- document the test in README

## Testing
- `bash -n cdev_test`

------
https://chatgpt.com/codex/tasks/task_b_6850eb229b748320930cecf8ad631e87